### PR TITLE
Fix Fuzzy Match Environment Check; Add Status & Shuffling Toggle

### DIFF
--- a/itunes/commands.go
+++ b/itunes/commands.go
@@ -77,7 +77,7 @@ var commands = []cli.Command{
 	{
 		Name:    "shuffle",
 		Aliases: []string{"shuf", "sh"},
-		Usage:   "Enables snuffling of the current playlist",
+		Usage:   "Enables or disables shuffling. Set with ON or OFF.",
 		Action:  shuffle,
 	},
 }

--- a/itunes/main.go
+++ b/itunes/main.go
@@ -1,20 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
 )
-
-const fuzzy = "ITUNES_CLI_FUZZY_TOOL"
-
-func init() {
-	if os.Getenv(fuzzy) == "" {
-		fmt.Fprintln(os.Stderr, "please set environment variable: $"+fuzzy)
-		os.Exit(1)
-	}
-}
 
 func main() {
 	app := cli.NewApp()


### PR DESCRIPTION
I couldn't find any documentation around the error I was receiving regarding the fuzzy cli tool environment variable. In looking at your change log it looks like this was removed from the documentation with a recent change, but the check in main.go remained so I removed it.

I also added a couple of commands related to getting iTunes status and the ability to enable/disable shuffling.

I've never written anything in Go prior to this, so I welcome any refactoring suggestions. In particular I think the conversion of the command line argument of "on/off" to a bool as a string to pass to the tell command is ugly.